### PR TITLE
BatchQ template: include input/output files as #BATCHQ -input/-output

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1,5 +1,5 @@
 <project name="cgpipe" default="jar">
-   <property name="version" value="0.5.18"/>
+   <property name="version" value="0.5.19"/>
     <property name="lib.dir" value="lib"/>
     <property name="blib.dir" value="blib"/>
     <property name="build.dir" value="build"/>

--- a/src/java/io/compgen/cgpipe/runner/BatchQTemplateRunner.template.cgp
+++ b/src/java/io/compgen/cgpipe/runner/BatchQTemplateRunner.template.cgp
@@ -26,6 +26,16 @@ if job.procs > 1 %>
 <% if job.stderr %>
 #BATCHQ -stderr ${job.stderr}
 <% endif %>
+<% for input in job._inputs %>
+<% if input %>
+#BATCHQ -input ${input}
+<% endif %>
+<% done %>
+<% for output in job._outputs %>
+<% if output %>
+#BATCHQ -output ${output}
+<% endif %>
+<% done %>
 <% for custom in job.custom %>
 <% if custom %>
 #BATCHQ ${custom}

--- a/src/java/io/compgen/cgpipe/runner/TemplateRunner.java
+++ b/src/java/io/compgen/cgpipe/runner/TemplateRunner.java
@@ -73,7 +73,7 @@ public abstract class TemplateRunner extends JobRunner {
 		}
 
 		cxt.set("job._body", new VarString(jobdef.getBody()));
-		
+
 		VarList outputs = new VarList();
 		for (String out:jobdef.getOutputs()) {
 			try {
@@ -81,8 +81,18 @@ public abstract class TemplateRunner extends JobRunner {
 			} catch (VarTypeException e) {
 			}
 		}
-		
+
 		cxt.set("job._outputs", outputs);
+
+		VarList inputs = new VarList();
+		for (String in:jobdef.getInputs()) {
+			try {
+				inputs.add(new VarString(in));
+			} catch (VarTypeException e) {
+			}
+		}
+
+		cxt.set("job._inputs", inputs);
 		
 		if (!cxt.contains("job.wd")) {
 			try {

--- a/src/test-scripts/runners/batchq/01-basic.expected/submit-1.stdin
+++ b/src/test-scripts/runners/batchq/01-basic.expected/submit-1.stdin
@@ -1,5 +1,6 @@
 #!/bin/bash
 #BATCHQ -name cgjob_output.txt
+#BATCHQ -output output.txt
 #BATCHQ -wd .
 set -eo pipefail
 echo "hello world" > output.txt

--- a/src/test-scripts/runners/batchq/02-mem-procs.expected/submit-1.stdin
+++ b/src/test-scripts/runners/batchq/02-mem-procs.expected/submit-1.stdin
@@ -2,6 +2,7 @@
 #BATCHQ -name cgjob_output.txt
 #BATCHQ -procs 4
 #BATCHQ -mem 8G
+#BATCHQ -output output.txt
 #BATCHQ -wd .
 set -eo pipefail
 echo "hello" > output.txt

--- a/src/test-scripts/runners/batchq/03-walltime-mail.expected/submit-1.stdin
+++ b/src/test-scripts/runners/batchq/03-walltime-mail.expected/submit-1.stdin
@@ -2,6 +2,7 @@
 #BATCHQ -name cgjob_output.txt
 #BATCHQ -walltime 01:00:00
 #BATCHQ -mail alice@example.com
+#BATCHQ -output output.txt
 #BATCHQ -wd .
 set -eo pipefail
 echo hi > output.txt

--- a/src/test-scripts/runners/batchq/04-dependencies.expected/submit-1.stdin
+++ b/src/test-scripts/runners/batchq/04-dependencies.expected/submit-1.stdin
@@ -1,5 +1,6 @@
 #!/bin/bash
 #BATCHQ -name cgjob_stage1.txt
+#BATCHQ -output stage1.txt
 #BATCHQ -wd .
 set -eo pipefail
 echo upstream > stage1.txt

--- a/src/test-scripts/runners/batchq/04-dependencies.expected/submit-2.stdin
+++ b/src/test-scripts/runners/batchq/04-dependencies.expected/submit-2.stdin
@@ -1,6 +1,8 @@
 #!/bin/bash
 #BATCHQ -name cgjob_stage2.txt
 #BATCHQ -afterok 10001
+#BATCHQ -input stage1.txt
+#BATCHQ -output stage2.txt
 #BATCHQ -wd .
 set -eo pipefail
 cat stage1.txt > stage2.txt

--- a/src/test-scripts/runners/batchq/05-hold-release.expected/submit-1.stdin
+++ b/src/test-scripts/runners/batchq/05-hold-release.expected/submit-1.stdin
@@ -1,5 +1,6 @@
 #!/bin/bash
 #BATCHQ -name cgjob_output.txt
+#BATCHQ -output output.txt
 #BATCHQ -wd .
 set -eo pipefail
 echo hi > output.txt

--- a/src/test-scripts/runners/batchq/06-abort-cancels.expected/stdout
+++ b/src/test-scripts/runners/batchq/06-abort-cancels.expected/stdout
@@ -4,6 +4,8 @@ CGPIPE ERROR Bad return code from submit: batchq submit  => (1) mock: forced fai
 #!/bin/bash
 #BATCHQ -name cgjob_stage2.txt
 #BATCHQ -afterok 10001
+#BATCHQ -input stage1.txt
+#BATCHQ -output stage2.txt
 #BATCHQ -wd .
 set -eo pipefail
 cat stage1.txt > stage2.txt

--- a/src/test-scripts/runners/batchq/06-abort-cancels.expected/submit-1.stdin
+++ b/src/test-scripts/runners/batchq/06-abort-cancels.expected/submit-1.stdin
@@ -1,5 +1,6 @@
 #!/bin/bash
 #BATCHQ -name cgjob_stage1.txt
+#BATCHQ -output stage1.txt
 #BATCHQ -wd .
 set -eo pipefail
 echo upstream > stage1.txt

--- a/src/test-scripts/runners/batchq/06-abort-cancels.expected/submit-2.stdin
+++ b/src/test-scripts/runners/batchq/06-abort-cancels.expected/submit-2.stdin
@@ -1,6 +1,8 @@
 #!/bin/bash
 #BATCHQ -name cgjob_stage2.txt
 #BATCHQ -afterok 10001
+#BATCHQ -input stage1.txt
+#BATCHQ -output stage2.txt
 #BATCHQ -wd .
 set -eo pipefail
 cat stage1.txt > stage2.txt

--- a/src/test-scripts/runners/batchq/07-custom-directives.expected/submit-1.stdin
+++ b/src/test-scripts/runners/batchq/07-custom-directives.expected/submit-1.stdin
@@ -1,5 +1,6 @@
 #!/bin/bash
 #BATCHQ -name cgjob_output.txt
+#BATCHQ -output output.txt
 #BATCHQ -gpu 1
 #BATCHQ -feature avx512
 #BATCHQ -wd .

--- a/src/test-scripts/runners/batchq/08-setup-block.expected/submit-1.stdin
+++ b/src/test-scripts/runners/batchq/08-setup-block.expected/submit-1.stdin
@@ -1,5 +1,6 @@
 #!/bin/bash
 #BATCHQ -name cgjob_output.txt
+#BATCHQ -output output.txt
 #BATCHQ -wd .
 set -eo pipefail
 module load foo

--- a/src/test-scripts/runners/batchq/10-isjobidvalid-stale.expected/submit-1.stdin
+++ b/src/test-scripts/runners/batchq/10-isjobidvalid-stale.expected/submit-1.stdin
@@ -1,5 +1,6 @@
 #!/bin/bash
 #BATCHQ -name cgjob_output.txt
+#BATCHQ -output output.txt
 #BATCHQ -wd .
 set -eo pipefail
 echo hi > output.txt

--- a/src/test-scripts/runners/batchq/11-batchqhome.expected/submit-1.stdin
+++ b/src/test-scripts/runners/batchq/11-batchqhome.expected/submit-1.stdin
@@ -1,5 +1,6 @@
 #!/bin/bash
 #BATCHQ -name cgjob_output.txt
+#BATCHQ -output output.txt
 #BATCHQ -wd .
 set -eo pipefail
 echo hi > output.txt


### PR DESCRIPTION
Inputs from JobDef.getInputs() and outputs from JobDef.getOutputs() are exposed to template runners as job._inputs / job._outputs (the latter already existed). The BatchQ template emits one #BATCHQ -input <file> line per input and one #BATCHQ -output <file> line per output, between the stdout/stderr block and the job.custom block.

AI assisted